### PR TITLE
add an initialize method to Heap

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,18 @@ impl Heap {
         }
     }
 
+    /// Initializes an empty heap
+    ///
+    /// # Unsafety
+    ///
+    /// This function must be called at most once and must only be used on an
+    /// empty heap.
+    pub unsafe fn init(&mut self, heap_bottom: usize, heap_size: usize) {
+        self.bottom = heap_bottom;
+        self.size = heap_size;
+        self.holes = HoleList::new(heap_bottom, heap_size);
+    }
+
     /// Creates a new heap with the given `bottom` and `size`. The bottom address must be valid
     /// and the memory in the `[heap_bottom, heap_bottom + heap_size)` range must not be used for
     /// anything else. This function is unsafe because it can cause undefined behavior if the


### PR DESCRIPTION
this lets you create an allocator that doesn't depend on lazy_init.
Example below:

``` rust
static HEAP: Mutex<Heap> = Mutex::new(Heap::new());

unsafe fn before_main() {
    HEAP.lock().init(BOTTOM, SIZE);
}

fn main() {
    // Use the allocator
}
```