### PR TITLE
Make it possible to extend the size of the heap

### DIFF
--- a/src/hole.rs
+++ b/src/hole.rs
@@ -26,11 +26,11 @@ impl HoleList {
         assert!(size_of::<Hole>() == Self::min_size());
 
         let ptr = hole_addr as *mut Hole;
-        mem::forget(mem::replace(&mut *ptr,
-                                 Hole {
-                                     size: hole_size,
-                                     next: None,
-                                 }));
+        mem::replace(&mut *ptr,
+                     Hole {
+                         size: hole_size,
+                         next: None,
+                     });
 
         HoleList {
             first: Hole {
@@ -283,7 +283,7 @@ fn deallocate(mut hole: &mut Hole, addr: usize, mut size: usize) {
                 };
                 // write the new hole to the freed memory
                 let ptr = addr as *mut Hole;
-                mem::forget(mem::replace(unsafe { &mut *ptr }, new_hole));
+                mem::replace(unsafe { &mut *ptr }, new_hole);
                 // add the F block as the next block of the X block
                 hole.next = Some(unsafe { Unique::new(ptr) });
             }

--- a/src/hole.rs
+++ b/src/hole.rs
@@ -240,10 +240,14 @@ fn deallocate(mut hole: &mut Hole, addr: usize, mut size: usize) {
                 hole.size += size + next.size; // merge the F and Y blocks to this X block
                 hole.next = hole.next_unwrap().next.take(); // remove the Y block
             }
-            Some(_) if hole_addr + hole.size == addr => {
+            _ if hole_addr + hole.size == addr => {
                 // block is right behind this hole but there is used memory after it
                 // before:  ___XXX______YYYYY____    where X is this hole and Y the next hole
                 // after:   ___XXXFFFF__YYYYY____    where F is the freed block
+
+                // or: block is right behind this hole and this is the last hole
+                // before:  ___XXX_______________    where X is this hole and Y the next hole
+                // after:   ___XXXFFFF___________    where F is the freed block
 
                 hole.size += size; // merge the F block to this X block
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,22 @@ impl Heap {
     pub fn size(&self) -> usize {
         self.size
     }
+
+    /// Return the top address of the heap
+    pub fn top(&self) -> usize {
+        self.bottom + self.size
+    }
+
+    /// Extends the size of the heap by creating a new hole at the end
+    ///
+    /// # Unsafety
+    ///
+    /// The new extended area must be valid
+    pub unsafe fn extend(&mut self, by: usize) {
+        let top = self.top();
+        self.holes.deallocate(top as *mut u8, by);
+        self.size += by;
+    }
 }
 
 /// Align downwards. Returns the greatest x with alignment `align`


### PR DESCRIPTION
Add a max_size parameter to the heap.
Allocations exceeding the size of the heap will fail,
but one can extend the size of the heap with the call to extend.

That allows heap to be more memory efficient, consuming more memory only
when necessary, eg. os allocator might map additional virtual memory when
the allocation fails.