### PR TITLE
Add a feature to make spin use optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,10 @@ repository = "https://github.com/phil-opp/linked-list-allocator"
 documentation = "https://docs.rs/crate/linked_list_allocator"
 homepage = "http://os.phil-opp.com/kernel-heap.html#a-better-allocator"
 
-[dependencies]
+[features]
+default = ["use_spin"]
+use_spin = ["spin"]
+
+[dependencies.spin]
 spin = "0.4.5"
+optional = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,12 +9,15 @@ extern crate alloc;
 #[macro_use]
 extern crate std;
 
+#[cfg(feature = "use_spin")]
 extern crate spin;
 
 use hole::{Hole, HoleList};
 use core::mem;
+#[cfg(feature = "use_spin")]
 use core::ops::Deref;
 use alloc::allocator::{Alloc, Layout, AllocErr};
+#[cfg(feature = "use_spin")]
 use spin::Mutex;
 
 mod hole;
@@ -138,8 +141,10 @@ unsafe impl Alloc for Heap {
     }
 }
 
+#[cfg(feature = "use_spin")]
 pub struct LockedHeap(Mutex<Heap>);
 
+#[cfg(feature = "use_spin")]
 impl LockedHeap {
     /// Creates an empty heap. All allocate calls will return `None`.
     pub const fn empty() -> LockedHeap {
@@ -159,6 +164,7 @@ impl LockedHeap {
     }
 }
 
+#[cfg(feature = "use_spin")]
 impl Deref for LockedHeap {
     type Target = Mutex<Heap>;
 
@@ -167,6 +173,7 @@ impl Deref for LockedHeap {
     }
 }
 
+#[cfg(feature = "use_spin")]
 unsafe impl<'a> Alloc for &'a LockedHeap {
     unsafe fn alloc(&mut self, layout: Layout) -> Result<*mut u8, AllocErr> {
         self.0.lock().allocate_first_fit(layout)


### PR DESCRIPTION
Hi @phil-opp and thanks for your really useful crate!

I'm using it to create an allocator for a Cortex-M0. 
Unfortunately the spin Mutex is not supported as it uses [the sync AtomicBool](https://doc.rust-lang.org/std/sync/atomic/struct.AtomicBool.html) which is not defined for this architecture. 

So I've forked your repo to add a feature that make spin optional and if it's defined, it enables the LockedHeap. Thus, it is still compatible with other uses such as the one in https://github.com/pollen/alloc-cortex-m for instance where it uses its own Mutex to define a LockedHeap.

Let me know if you would be interested in integrating this.

Cheers!
Pierre