### PR TITLE
Fix use of unstable library feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![feature(const_fn)]
 #![feature(alloc, allocator_api)]
 #![no_std]
+#![feature(ptr_internals)]
 
 extern crate alloc;
 


### PR DESCRIPTION
Tried compiling with rust nightly (1/21/18) and got the following error:

```
error[E0658]: use of unstable library feature 'ptr_internals': use NonNull instead and consider PhantomData<T> (if you also use #[may_dangle]), Send, and/or Sync (see issue #0)
 --> ~/.cargo/registry/src/github.com-1ecc6299db9ec823/linked_list_allocator-0.4.3/src/hole.rs:1:5
  |
1 | use core::ptr::Unique;
  |     ^^^^^^^^^^^^^^^^^
  |
  = help: add #![feature(ptr_internals)] to the crate attributes to enable
```

The proposed fix should turn off this warning, but goes against the advice presented in the error to use NonNull and PhantomData<T>.