### PR TITLE
Update for the latest nightly alloc interface.

### DIFF
--- a/src/hole.rs
+++ b/src/hole.rs
@@ -1,4 +1,4 @@
-use core::alloc::{AllocErr, Layout, Opaque};
+use alloc::allocator::{AllocErr, Layout};
 use core::mem::size_of;
 use core::ptr::NonNull;
 
@@ -46,7 +46,7 @@ impl HoleList {
     /// block is returned.
     /// This function uses the “first fit” strategy, so it uses the first hole that is big
     /// enough. Thus the runtime is in O(n) but it should be reasonably fast for small allocations.
-    pub fn allocate_first_fit(&mut self, layout: Layout) -> Result<NonNull<Opaque>, AllocErr> {
+    pub fn allocate_first_fit(&mut self, layout: Layout) -> Result<NonNull<u8>, AllocErr> {
         assert!(layout.size() >= Self::min_size());
 
         allocate_first_fit(&mut self.first, layout).map(|allocation| {
@@ -56,7 +56,7 @@ impl HoleList {
             if let Some(padding) = allocation.back_padding {
                 deallocate(&mut self.first, padding.addr, padding.size);
             }
-            NonNull::new(allocation.info.addr as *mut Opaque).unwrap()
+            NonNull::new(allocation.info.addr as *mut u8).unwrap()
         })
     }
 
@@ -66,7 +66,7 @@ impl HoleList {
     /// This function walks the list and inserts the given block at the correct place. If the freed
     /// block is adjacent to another free block, the blocks are merged again.
     /// This operation is in `O(n)` since the list needs to be sorted by address.
-    pub unsafe fn deallocate(&mut self, ptr: NonNull<Opaque>, layout: Layout) {
+    pub unsafe fn deallocate(&mut self, ptr: NonNull<u8>, layout: Layout) {
         deallocate(&mut self.first, ptr.as_ptr() as usize, layout.size())
     }
 


### PR DESCRIPTION
Update `linked_list_allocator` to work with the latest
alloc::allocator interface from nightly Rust.

Tested with `cargo test`. Note I did not update the version.