### PR TITLE
Update spin dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ default = ["use_spin"]
 use_spin = ["spin"]
 
 [dependencies.spin]
-version = "0.4.5"
+version = "0.4.8"
 optional = true


### PR DESCRIPTION
Update the dependency on `spin` to that crate's latest
revision (0.4.8).

Tested via `cargo test`.