### PR TITLE
Fix build on nightly 1.43.0 (05-03-2020).

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,8 +130,8 @@ impl Heap {
 }
 
 unsafe impl AllocRef for Heap {
-    unsafe fn alloc(&mut self, layout: Layout) -> Result<NonNull<u8>, AllocErr> {
-        self.allocate_first_fit(layout)
+    unsafe fn alloc(&mut self, layout: Layout) -> Result<(NonNull<u8>, usize), AllocErr> {
+        Ok((self.allocate_first_fit(layout)?, layout.size()))
     }
 
     unsafe fn dealloc(&mut self, ptr: NonNull<u8>, layout: Layout) {


### PR DESCRIPTION
The AllocRef trait has been changed slightly.
See https://doc.rust-lang.org/nightly/std/alloc/trait.AllocRef.html#tymethod.alloc.

Fix #24 