### PR TITLE
Make AllocRef implementation optional behind new `alloc_ref` feature

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,65 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - 'master'
+    tags:
+      - '*'
+  schedule:
+    - cron: '40 5 * * *'   # every day at 5:40
+  pull_request:
+
+jobs:
+  test:
+    name: "Test"
+
+    strategy:
+      matrix:
+        platform: [
+          ubuntu-latest,
+          macos-latest,
+          windows-latest
+        ]
+
+    runs-on: ${{ matrix.platform }}
+    timeout-minutes: 15
+
+    steps:
+    - name: "Checkout Repository"
+      uses: actions/checkout@v1
+
+    - name: Install Rustup
+      run: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly
+        echo ::add-path::$HOME/.cargo/bin
+      if: runner.os == 'macOS'
+
+    - name: Set Rustup profile to minimal
+      run: rustup set profile minimal
+
+    - name: "Print Rust Version"
+      run: |
+        rustc -Vv
+        cargo -Vv
+
+    - name: "Run cargo build"
+      run: cargo build
+
+    - name: "Build with `alloc_ref` feature"
+      run: cargo build --features alloc_ref
+
+    - name: "Run cargo test"
+      run: cargo test
+
+    - name: 'Deny Warnings'
+      run: cargo rustc -- -D warnings
+
+  check_formatting:
+    name: "Check Formatting"
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+    - uses: actions/checkout@v1
+    - run: rustup install nightly
+    - run: cargo +nightly fmt -- --check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ homepage = "http://os.phil-opp.com/kernel-heap.html#a-better-allocator"
 [features]
 default = ["use_spin"]
 use_spin = ["spinning_top"]
+alloc_ref = []
 
 [dependencies.spinning_top]
 version = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -28,5 +28,14 @@ pub fn init_heap() {
 }
 ```
 
+## Features
+
+- **`use_spin`** (default): Provide a `LockedHeap` type that implements the [`GlobalAlloc`] trait by using a spinlock.
+- **`alloc_ref`**: Provide an implementation of the unstable [`AllocRef`] trait.
+    - Warning: The `AllocRef` trait is still regularly changed on the Rust side, so expect some regular breakage when using this feature.
+
+[`GlobalAlloc`]: https://doc.rust-lang.org/nightly/core/alloc/trait.GlobalAlloc.html
+[`AllocRef`]: https://doc.rust-lang.org/nightly/core/alloc/trait.AllocRef.html
+
 ## License
 This crate is dual-licensed under MIT or the Apache License (Version 2.0). See LICENSE-APACHE and LICENSE-MIT for details.

--- a/src/hole.rs
+++ b/src/hole.rs
@@ -1,4 +1,4 @@
-use alloc::alloc::{AllocErr, Layout};
+use alloc::alloc::Layout;
 use core::mem::{align_of, size_of};
 use core::ptr::NonNull;
 
@@ -49,7 +49,7 @@ impl HoleList {
     /// block is returned.
     /// This function uses the “first fit” strategy, so it uses the first hole that is big
     /// enough. Thus the runtime is in O(n) but it should be reasonably fast for small allocations.
-    pub fn allocate_first_fit(&mut self, layout: Layout) -> Result<NonNull<u8>, AllocErr> {
+    pub fn allocate_first_fit(&mut self, layout: Layout) -> Result<NonNull<u8>, ()> {
         assert!(layout.size() >= Self::min_size());
 
         allocate_first_fit(&mut self.first, layout).map(|allocation| {
@@ -192,7 +192,7 @@ fn split_hole(hole: HoleInfo, required_layout: Layout) -> Option<Allocation> {
 /// care of freeing it again.
 /// This function uses the “first fit” strategy, so it breaks as soon as a big enough hole is
 /// found (and returns it).
-fn allocate_first_fit(mut previous: &mut Hole, layout: Layout) -> Result<Allocation, AllocErr> {
+fn allocate_first_fit(mut previous: &mut Hole, layout: Layout) -> Result<Allocation, ()> {
     loop {
         let allocation: Option<Allocation> = previous
             .next
@@ -210,7 +210,7 @@ fn allocate_first_fit(mut previous: &mut Hole, layout: Layout) -> Result<Allocat
             }
             None => {
                 // this was the last hole, so no hole is big enough -> allocation not possible
-                return Err(AllocErr);
+                return Err(());
             }
         }
     }


### PR DESCRIPTION
The `AllocRef` trait repeatedly changed and caused breakage recently (see #24 and #19). For this reason, I think it's better to make this feature optional so that users that only need the `LockedHeap` type don't experience possible future breaking changes of the `AllocRef` trait.

cc #25 