### PR TITLE
Prevent writing to heap memory range when size too small

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,10 +61,14 @@ impl Heap {
     /// anything else. This function is unsafe because it can cause undefined behavior if the
     /// given address is invalid.
     pub unsafe fn new(heap_bottom: usize, heap_size: usize) -> Heap {
-        Heap {
-            bottom: heap_bottom,
-            size: heap_size,
-            holes: HoleList::new(heap_bottom, heap_size),
+        if heap_size < HoleList::min_size() {
+            Self::empty()
+        } else {
+            Heap {
+                bottom: heap_bottom,
+                size: heap_size,
+                holes: HoleList::new(heap_bottom, heap_size),
+            }
         }
     }
 


### PR DESCRIPTION
Added check to prevent creation of hole if heap is too small.