### PR TITLE
feat(stable): Build on stable without features

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,35 @@ jobs:
     - name: 'Deny Warnings'
       run: cargo rustc -- -D warnings
 
+  test-stable:
+    name: "Test stable without features"
+
+    strategy:
+      matrix:
+        platform: [
+            ubuntu-latest,
+            macos-latest,
+            windows-latest
+        ]
+
+    runs-on: ${{ matrix.platform }}
+    timeout-minutes: 15
+
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v1
+
+      - name: "Print Rust Version"
+        run: |
+          rustc -Vv
+          cargo -Vv
+
+      - name: "Build without feature on stable"
+        run: cargo +stable build --no-default-features
+
+      - name: "Run cargo test without features on stable"
+        run: cargo +stable test --no-default-features
+
   test-unstable:
     name: "Test unstable features"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,10 @@ documentation = "https://docs.rs/crate/linked_list_allocator"
 homepage = "http://os.phil-opp.com/kernel-heap.html#a-better-allocator"
 
 [features]
-default = ["use_spin"]
+default = ["use_spin", "const_mut_refs"]
 use_spin = ["spinning_top"]
 alloc_ref = []
+const_mut_refs = []
 
 [dependencies.spinning_top]
 version = "0.1.0"

--- a/src/hole.rs
+++ b/src/hole.rs
@@ -11,6 +11,18 @@ pub struct HoleList {
 
 impl HoleList {
     /// Creates an empty `HoleList`.
+    #[cfg(not(feature = "const_mut_refs"))]
+    pub fn empty() -> HoleList {
+        HoleList {
+            first: Hole {
+                size: 0,
+                next: None,
+            },
+        }
+    }
+
+    /// Creates an empty `HoleList`.
+    #[cfg(feature = "const_mut_refs")]
     pub const fn empty() -> HoleList {
         HoleList {
             first: Hole {
@@ -26,7 +38,7 @@ impl HoleList {
     ///
     /// The pointer to `hole_addr` is automatically aligned.
     pub unsafe fn new(hole_addr: usize, hole_size: usize) -> HoleList {
-        assert!(size_of::<Hole>() == Self::min_size());
+        assert_eq!(size_of::<Hole>(), Self::min_size());
 
         let aligned_hole_addr = align_up(hole_addr, align_of::<Hole>());
         let ptr = aligned_hole_addr as *mut Hole;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(const_mut_refs)]
+#![cfg_attr(feature = "const_mut_refs", feature(const_mut_refs))]
 #![cfg_attr(
     feature = "alloc_ref",
     feature(allocator_api, alloc_layout_extra, nonnull_slice_from_raw_parts)
@@ -41,6 +41,17 @@ pub struct Heap {
 
 impl Heap {
     /// Creates an empty heap. All allocate calls will return `None`.
+    #[cfg(not(feature = "const_mut_refs"))]
+    pub fn empty() -> Heap {
+        Heap {
+            bottom: 0,
+            size: 0,
+            used: 0,
+            holes: HoleList::empty(),
+        }
+    }
+
+    #[cfg(feature = "const_mut_refs")]
     pub const fn empty() -> Heap {
         Heap {
             bottom: 0,


### PR DESCRIPTION
To built on stable, the `const_mut_refs` feature cannot be used, so
introduce a crate feature `const_mut_refs`, which is on by default.