### PR TITLE
fix: do not require alloc crate

### DIFF
--- a/src/hole.rs
+++ b/src/hole.rs
@@ -1,4 +1,4 @@
-use alloc::alloc::Layout;
+use core::alloc::Layout;
 use core::mem::{align_of, size_of};
 use core::ptr::NonNull;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,13 +12,11 @@ extern crate std;
 #[cfg(feature = "use_spin")]
 extern crate spinning_top;
 
-extern crate alloc;
-
-use alloc::alloc::Layout;
-#[cfg(feature = "alloc_ref")]
-use alloc::alloc::{AllocError, Allocator};
 #[cfg(feature = "use_spin")]
 use core::alloc::GlobalAlloc;
+use core::alloc::Layout;
+#[cfg(feature = "alloc_ref")]
+use core::alloc::{AllocError, Allocator};
 use core::mem;
 #[cfg(feature = "use_spin")]
 use core::ops::Deref;


### PR DESCRIPTION
Using `core::alloc` instead of `alloc::alloc` removes the need to
include `alloc` in this library. This enables users of this crate to use
`Heap` without `alloc` in `no_std`.