### PR TITLE
Made hole.rs public for external uses.

### DIFF
--- a/src/hole.rs
+++ b/src/hole.rs
@@ -1,8 +1,8 @@
 use core::alloc::Layout;
 use core::mem;
 use core::mem::{align_of, size_of};
-
 use core::ptr::NonNull;
+
 use super::align_up;
 
 /// A sorted list of holes. It uses the the holes itself to store its nodes.
@@ -322,7 +322,9 @@ fn deallocate(mut hole: &mut Hole, addr: usize, mut size: usize) {
                 // write the new hole to the freed memory
                 debug_assert_eq!(addr % align_of::<Hole>(), 0);
                 let ptr = addr as *mut Hole;
-                unsafe { ptr.write(new_hole) };
+                unsafe {
+                    ptr.write(new_hole)
+                };
                 // add the F block as the next block of the X block
                 hole.next = Some(unsafe { &mut *ptr });
             }

--- a/src/hole.rs
+++ b/src/hole.rs
@@ -88,7 +88,7 @@ impl HoleList {
 
             (
                 NonNull::new(allocation.info.addr as *mut u8).unwrap(),
-                aligned_layout
+                aligned_layout,
             )
         })
     }
@@ -104,7 +104,7 @@ impl HoleList {
         deallocate(
             &mut self.first,
             ptr.as_ptr() as usize,
-            aligned_layout.size()
+            aligned_layout.size(),
         );
         aligned_layout
     }

--- a/src/hole.rs
+++ b/src/hole.rs
@@ -3,6 +3,7 @@ use core::mem::{align_of, size_of};
 use core::ptr::NonNull;
 
 use super::align_up;
+use core::mem;
 
 /// A sorted list of holes. It uses the the holes itself to store its nodes.
 pub struct HoleList {
@@ -53,6 +54,20 @@ impl HoleList {
                 next: Some(&mut *ptr),
             },
         }
+    }
+
+
+    /// Align layout. Returns a layout with size increased to
+    /// fit at least `HoleList::min_size` and proper alignment of a `Hole`.
+    pub fn align_layout(layout: Layout) -> Layout {
+        let mut size = layout.size();
+        if size < Self::min_size() {
+            size = Self::min_size();
+        }
+        let size = align_up(size, mem::align_of::<Hole>());
+        let layout = Layout::from_size_align(size, layout.align()).unwrap();
+
+        layout
     }
 
     /// Searches the list for a big enough hole. A hole is big enough if it can hold an allocation

--- a/src/hole.rs
+++ b/src/hole.rs
@@ -56,7 +56,6 @@ impl HoleList {
         }
     }
 
-
     /// Align layout. Returns a layout with size increased to
     /// fit at least `HoleList::min_size` and proper alignment of a `Hole`.
     pub fn align_layout(layout: Layout) -> Layout {
@@ -322,9 +321,7 @@ fn deallocate(mut hole: &mut Hole, addr: usize, mut size: usize) {
                 // write the new hole to the freed memory
                 debug_assert_eq!(addr % align_of::<Hole>(), 0);
                 let ptr = addr as *mut Hole;
-                unsafe {
-                    ptr.write(new_hole)
-                };
+                unsafe { ptr.write(new_hole) };
                 // add the F block as the next block of the X block
                 hole.next = Some(unsafe { &mut *ptr });
             }

--- a/src/hole.rs
+++ b/src/hole.rs
@@ -85,7 +85,11 @@ impl HoleList {
             if let Some(padding) = allocation.back_padding {
                 deallocate(&mut self.first, padding.addr, padding.size);
             }
-            (NonNull::new(allocation.info.addr as *mut u8).unwrap(), aligned_layout)
+
+            (
+                NonNull::new(allocation.info.addr as *mut u8).unwrap(),
+                aligned_layout
+            )
         })
     }
 
@@ -97,7 +101,11 @@ impl HoleList {
     /// This operation is in `O(n)` since the list needs to be sorted by address.
     pub unsafe fn deallocate(&mut self, ptr: NonNull<u8>, layout: Layout) -> Layout {
         let aligned_layout = Self::align_layout(layout);
-        deallocate(&mut self.first, ptr.as_ptr() as usize, aligned_layout.size());
+        deallocate(
+            &mut self.first,
+            ptr.as_ptr() as usize,
+            aligned_layout.size()
+        );
         aligned_layout
     }
 

--- a/src/hole.rs
+++ b/src/hole.rs
@@ -1,9 +1,9 @@
 use core::alloc::Layout;
-use core::mem::{align_of, size_of};
-use core::ptr::NonNull;
-
-use super::align_up;
 use core::mem;
+use core::mem::{align_of, size_of};
+
+use core::ptr::NonNull;
+use super::align_up;
 
 /// A sorted list of holes. It uses the the holes itself to store its nodes.
 pub struct HoleList {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ use core::alloc::{AllocError, Allocator};
 #[cfg(feature = "use_spin")]
 use core::ops::Deref;
 use core::ptr::NonNull;
-use hole::HoleList;
+use hole::{Hole, HoleList};
 #[cfg(feature = "use_spin")]
 use spinning_top::Spinlock;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,9 +20,9 @@ use core::alloc::{AllocError, Allocator};
 #[cfg(feature = "use_spin")]
 use core::ops::Deref;
 use core::ptr::NonNull;
-use hole::HoleList;
 #[cfg(test)]
 use hole::Hole;
+use hole::HoleList;
 #[cfg(feature = "use_spin")]
 use spinning_top::Spinlock;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,15 +17,14 @@ use core::alloc::GlobalAlloc;
 use core::alloc::Layout;
 #[cfg(feature = "alloc_ref")]
 use core::alloc::{AllocError, Allocator};
-use core::mem;
 #[cfg(feature = "use_spin")]
 use core::ops::Deref;
 use core::ptr::NonNull;
-use hole::{Hole, HoleList};
+use hole::HoleList;
 #[cfg(feature = "use_spin")]
 use spinning_top::Spinlock;
 
-mod hole;
+pub mod hole;
 #[cfg(test)]
 mod test;
 
@@ -89,26 +88,13 @@ impl Heap {
         }
     }
 
-    /// Align layout. Returns a layout with size increased to
-    /// fit at least `HoleList::min_size` and proper alignment of a `Hole`.
-    fn align_layout(layout: Layout) -> Layout {
-        let mut size = layout.size();
-        if size < HoleList::min_size() {
-            size = HoleList::min_size();
-        }
-        let size = align_up(size, mem::align_of::<Hole>());
-        let layout = Layout::from_size_align(size, layout.align()).unwrap();
-
-        layout
-    }
-
     /// Allocates a chunk of the given size with the given alignment. Returns a pointer to the
     /// beginning of that chunk if it was successful. Else it returns `None`.
     /// This function scans the list of free memory blocks and uses the first block that is big
     /// enough. The runtime is in O(n) where n is the number of free blocks, but it should be
     /// reasonably fast for small allocations.
     pub fn allocate_first_fit(&mut self, layout: Layout) -> Result<NonNull<u8>, ()> {
-        let aligned_layout = Self::align_layout(layout);
+        let aligned_layout = HoleList::align_layout(layout);
         let res = self.holes.allocate_first_fit(aligned_layout);
         if res.is_ok() {
             self.used += aligned_layout.size();
@@ -124,7 +110,7 @@ impl Heap {
     /// correct place. If the freed block is adjacent to another free block, the blocks are merged
     /// again. This operation is in `O(n)` since the list needs to be sorted by address.
     pub unsafe fn deallocate(&mut self, ptr: NonNull<u8>, layout: Layout) {
-        let aligned_layout = Self::align_layout(layout);
+        let aligned_layout = HoleList::align_layout(layout);
         self.holes.deallocate(ptr, aligned_layout);
         self.used -= aligned_layout.size();
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,9 @@ use core::alloc::{AllocError, Allocator};
 #[cfg(feature = "use_spin")]
 use core::ops::Deref;
 use core::ptr::NonNull;
-use hole::{Hole, HoleList};
+use hole::HoleList;
+#[cfg(test)]
+use hole::Hole;
 #[cfg(feature = "use_spin")]
 use spinning_top::Spinlock;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,11 +96,13 @@ impl Heap {
     /// enough. The runtime is in O(n) where n is the number of free blocks, but it should be
     /// reasonably fast for small allocations.
     pub fn allocate_first_fit(&mut self, layout: Layout) -> Result<NonNull<u8>, ()> {
-        let res = self.holes.allocate_first_fit(layout);
-        if res.is_ok() {
-            self.used += res.unwrap().1.size();
+        match self.holes.allocate_first_fit(layout) {
+            Ok((ptr, aligned_layout)) => {
+                self.used += aligned_layout.size();
+                Ok(ptr)
+            },
+            Err(err) => Err(err),
         }
-        res.map(|tuple| tuple.0)
     }
 
     /// Frees the given allocation. `ptr` must be a pointer returned

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ impl Heap {
             Ok((ptr, aligned_layout)) => {
                 self.used += aligned_layout.size();
                 Ok(ptr)
-            },
+            }
             Err(err) => Err(err),
         }
     }


### PR DESCRIPTION
Hi Phil!

I've made hole.rs public for external uses and moved `align_layout()` function into `HoleList`.

`Heap` still contains the `size` and the `used` counters, so it is still `Heap` that uses `align_layout`.
Tell me if this is not the best solution