### PR TITLE
Update `spinning_top` dependency to `v0.2.3`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ alloc_ref = []
 const_mut_refs = []
 
 [dependencies.spinning_top]
-version = "0.1.0"
+version = "0.2.3"
 optional = true
 
 [package.metadata.release]

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Update `spinning_top` dependency to `v0.2.3` ([#50](https://github.com/phil-opp/linked-list-allocator/pull/50))
+
 # 0.8.11 – 2021-01-02
 
 - Add new `use_spin_nightly` feature, which, together with `const_mut_refs`, makes the `empty` method of `LockedHeap` const ([#49](https://github.com/phil-opp/linked-list-allocator/pull/49))


### PR DESCRIPTION
Fixes build on latest nightly (breakage introduced by https://github.com/rust-lang/rust/pull/84310).

This is a _breaking change_ because the exported `Spinlock`/`Mutex` type changed its API.