### PR TITLE
fix(alloc_ref): use renamed `dangling`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,7 +138,7 @@ jobs:
       MIRIFLAGS: "-Zmiri-disable-isolation -Zmiri-strict-provenance"
     steps:
     - uses: actions/checkout@v1
-    - run: rustup toolchain install nightly --profile minimal --component rust-src miri
+    - run: rustup toolchain install nightly --profile minimal --component rust-src --component miri
     - run: cargo +nightly miri test --all-features
 
   check_formatting:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,7 +267,7 @@ impl Heap {
 unsafe impl Allocator for LockedHeap {
     fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
         if layout.size() == 0 {
-            return Ok(NonNull::slice_from_raw_parts(layout.dangling(), 0));
+            return Ok(NonNull::slice_from_raw_parts(layout.dangling_ptr(), 0));
         }
         match self.0.lock().allocate_first_fit(layout) {
             Ok(ptr) => Ok(NonNull::slice_from_raw_parts(ptr, layout.size())),


### PR DESCRIPTION
As of nightly-2026-01-19, `dangling` was renamed to `dangling_ptr`:
https://github.com/rust-lang/rust/pull/148769#issue-3605478404

This closes #88.
